### PR TITLE
Allow unsubscribe

### DIFF
--- a/nostr/event.py
+++ b/nostr/event.py
@@ -77,7 +77,7 @@ class Event:
             bytes.fromhex(self.id), bytes.fromhex(self.signature), None, raw=True
         )
 
-    def to_message(self, subscription_id: Optional[str]) -> str:
+    def to_message(self, subscription_id: Optional[str] = None) -> str:
         resp: List[Any] = [ClientMessageType.EVENT]
         if subscription_id:
             resp.append(subscription_id)

--- a/views_api.py
+++ b/views_api.py
@@ -81,25 +81,7 @@ async def api_subscribe(filters: Filters):
         media_type="text/event-stream",
     )
 
-
 @nostrclient_ext.websocket("/api/v1/filters")
-async def ws_filters(websocket: WebSocket):
-    await websocket.accept()
-    while True:
-        json_data = await websocket.receive_text()
-        try:
-            data = json.loads(json_data)
-            filters = data if isinstance(data, list) else [data]
-            filters = [Filter.parse_obj(f) for f in filters]
-            nostr_filters = init_filters(filters)
-            async for message in event_getter(nostr_filters):
-                await websocket.send_text(message)
-
-        except Exception as e:
-            logger.warning(e)
-
-
-@nostrclient_ext.websocket("/api/v1/filters/subscribe")
 async def ws_filter_subscribe(websocket: WebSocket):
     await websocket.accept()
     while True:

--- a/views_api.py
+++ b/views_api.py
@@ -7,9 +7,7 @@ from fastapi.params import Depends
 from loguru import logger
 from sse_starlette.sse import EventSourceResponse
 
-from lnbits.decorators import (
-    check_admin,
-)
+from lnbits.decorators import check_admin
 from lnbits.helpers import urlsafe_short_hash
 
 from . import nostrclient_ext
@@ -81,6 +79,7 @@ async def api_subscribe(filters: Filters):
         media_type="text/event-stream",
     )
 
+
 @nostrclient_ext.websocket("/api/v1/filters")
 async def ws_filter_subscribe(websocket: WebSocket):
     await websocket.accept()
@@ -139,7 +138,9 @@ def init_filters(filters: List[Filter]):
     return nostr_filters
 
 
-async def event_getter(nostr_filters: NostrFilters, subscription_id: Optional[str] = None):
+async def event_getter(
+    nostr_filters: NostrFilters, subscription_id: Optional[str] = None
+):
     while True:
         event = await received_event_queue.get()
         if nostr_filters.match(event):


### PR DESCRIPTION
### Summary
This PR has one fix and one improvement.

**Fix**:
 - when no tag is present the value of `tags` should be `[]` and not `null`
See:
```py
    data = [0, public_key, created_at, kind, tags or [], content]
```
 - this helps correctly serialize the event and generate the correct event id


**Feature**:
- allow `subscription_id` to be used when filtering for events. This allows to:
  - unsubscribe when that filter is no longer needed
  - correlate the filter result with the filter (using  the `subscription_id`)