### PR TITLE
FIX: add urlsafe=True parameter to decrypt_internal_message

### DIFF
--- a/views_api.py
+++ b/views_api.py
@@ -131,7 +131,7 @@ async def ws_relay(ws_id: str, websocket: WebSocket) -> None:
         else:
             if not config.private_ws:
                 raise ValueError("Private websocket connections not accepted.")
-            if decrypt_internal_message(ws_id) != "relay":
+            if decrypt_internal_message(ws_id, urlsafe=True) != "relay":
                 raise ValueError("Invalid websocket endpoint.")
 
         await websocket.accept()


### PR DESCRIPTION
### Problem

In lnbits/lnbits#2984 we added a boolean flag for urlsafe encryption for scenarios like here with nostrclient where a websocket is being requested, but the API request failing with a `403` due to characters like `/` resulting from the encryption.

Without urlsafe being explicitly set in the nostrclient `decrypt_internal_message` function, it will default to False causing lnbits to try to decrypt the message using the wrong method:

```python
    def decrypt(self, encrypted: str, urlsafe: bool = False) -> str:
        """Decrypts a string using AES-256-CBC."""
        passphrase = self.passphrase

        if urlsafe:
            encrypted_bytes = base64.urlsafe_b64decode(encrypted)
        else:
            encrypted_bytes = base64.b64decode(encrypted) # it will use this method
```

### Solution

Update nostrclient `decrypt_internal` message with `urlsafe=True` boolean since it is an API endponit that will always require urlsafe values

```
            if decrypt_internal_message(ws_id, urlsafe=True) != "relay":
                raise ValueError("Invalid websocket endpoint.")
```

