### PR TITLE
Update default relay list

### DIFF
--- a/templates/nostrclient/index.html
+++ b/templates/nostrclient/index.html
@@ -466,8 +466,7 @@
         predefinedRelays: [
           'wss://relay.damus.io',
           'wss://nostr-pub.wellorder.net',
-          'wss://nostr.zebedee.cloud',
-          'wss://nodestr.fmt.wiz.biz',
+          'wss://relay.nostrconnect.com',
           'wss://nostr.oxtr.dev',
           'wss://nostr.wine'
         ]


### PR DESCRIPTION
nodestr.fmt.wiz.biz and the ZBD relays no longer exist. Added relay.nostrconnect.com as a new relay.