### PR TITLE
FIX: Ensure valid json

### DIFF
--- a/router.py
+++ b/router.py
@@ -116,7 +116,12 @@ class NostrRouter:
                 )
                 await self.websocket.send_text(event_to_forward)
         except Exception as e:
-            logger.debug(e)  # there are 2900 errors here
+            logger.warning(
+                f"[NOSTRCLIENT] Error in _handle_received_subscription_events: {e}"
+            )
+            logger.warning(
+                f"[NOSTRCLIENT] Event JSON was: {event_json[:100] if event_json else 'None'}..."
+            )
 
     def _handle_notices(self):
         while len(NostrRouter.received_subscription_notices):

--- a/router.py
+++ b/router.py
@@ -119,9 +119,6 @@ class NostrRouter:
             logger.warning(
                 f"[NOSTRCLIENT] Error in _handle_received_subscription_events: {e}"
             )
-            logger.warning(
-                f"[NOSTRCLIENT] Event JSON was: {event_json[:100] if event_json else 'None'}..."
-            )
 
     def _handle_notices(self):
         while len(NostrRouter.received_subscription_notices):

--- a/router.py
+++ b/router.py
@@ -111,7 +111,9 @@ class NostrRouter:
                 # this reconstructs the original response from the relay
                 # reconstruct original subscription id
                 s_original = self.original_subscription_ids[s]
-                event_to_forward = f"""["EVENT", "{s_original}", {event_json}]"""
+                event_to_forward = json.dumps(
+                    ["EVENT", s_original, json.loads(event_json)]
+                )
                 await self.websocket.send_text(event_to_forward)
         except Exception as e:
             logger.debug(e)  # there are 2900 errors here


### PR DESCRIPTION
# Fix: construct EVENT message with `json.dumps` instead of string interpolation

## Why

The old implementation built JSON-like strings by interpolation. This works for simple inputs, but as soon as values contain quotes, backslashes, or Unicode characters, the result is not valid JSON and will be rejected by relays.

## Change

```diff
- event_to_forward = f"""["EVENT", "{s_original}", {event_json}]"""
+ event_to_forward = json.dumps(["EVENT", s_original, json.loads(event_json)])
```

## Example of the problem

**Inputs**

```python
import json

s_original = 'sub"one'
event_json = '{"content": "hello \\"nostr\\"", "tags": []}'
```

**Old code**

```python
event_to_forward = f"""["EVENT", "{s_original}", {event_json}]"""
print(event_to_forward)
# ["EVENT", "sub"one", {"content": "hello \"nostr\"", "tags": []}]
json.loads(event_to_forward)
# raises json.decoder.JSONDecodeError
```

The string *looks* like JSON but cannot be parsed.

**New code**

```python
event_to_forward = json.dumps(["EVENT", s_original, json.loads(event_json)])
print(event_to_forward)
# ["EVENT", "sub\"one", {"content": "hello \"nostr\"", "tags": []}]
json.loads(event_to_forward)  # ✅ works
```

## Benefits

* Always produces valid JSON.
* Correctly escapes special characters in subscription IDs and event data.
* Removes risk of malformed payloads and relay rejections.
* Easier to maintain and extend (all inputs handled as objects, not string fragments).
