### PR TITLE
fix: reduce gap between Relay URL input and Add Relay button

### DIFF
--- a/templates/nostrclient/index.html
+++ b/templates/nostrclient/index.html
@@ -4,8 +4,8 @@
   <div class="col-12 col-md-7 q-gutter-y-md">
     <q-card>
       <q-form @submit="addRelay">
-        <div class="row">
-          <div class="col-12 col-md-7 q-pa-md">
+        <div class="row items-center q-pa-md q-col-gutter-sm">
+          <div class="col-12 col-md-7">
             <q-input
               outlined
               v-model="relayToAdd"
@@ -14,12 +14,11 @@
               label="Relay URL"
             ></q-input>
           </div>
-          <div class="col-6 col-md-3 q-pa-md">
+          <div class="col-auto">
             <q-btn-dropdown
               unelevated
               split
               color="primary"
-              class="float-left"
               type="submit"
               label="Add Relay"
             >
@@ -36,13 +35,13 @@
               </q-item>
             </q-btn-dropdown>
           </div>
-          <div class="col-6 col-md-2 q-pa-md">
+          <div class="col"></div>
+          <div class="col-auto">
             <q-btn
               unelevated
               @click="config.showDialog = true"
               color="primary"
               icon="settings"
-              class="float-right"
             ></q-btn>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Reduced excessive spacing between the Relay URL input and Add Relay button
- Uses `q-col-gutter-sm` instead of individual `q-pa-md` on columns for tighter layout
- Added `items-center` for proper vertical alignment
- Settings button remains right-aligned

## Issues Addressed
- Closes #58

## Test Plan
- [ ] Verify the Relay URL input and Add Relay button are closer together
- [ ] Verify layout still works on mobile (stacked) and desktop (side-by-side)
- [ ] Verify Settings button is still properly right-aligned

## Screenshot

<img width="1386" height="753" alt="image" src="https://github.com/user-attachments/assets/67656b80-a3f6-4cff-b547-2f934c06000d" />

🤖 Definitely not generated with [Claude Code](https://claude.com/claude-code)