### PR TITLE
Add NIP-01 OK and CLOSED responses for client messages

### DIFF
--- a/router.py
+++ b/router.py
@@ -133,7 +133,7 @@ class NostrRouter:
         assert len(json_data), "Bad JSON array"
 
         if json_data[0] == "REQ":
-            self._handle_client_req(json_data)
+            await self._handle_client_req(json_data)
             return
 
         if json_data[0] == "CLOSE":
@@ -141,12 +141,29 @@ class NostrRouter:
             return
 
         if json_data[0] == "EVENT":
-            nostr_client.relay_manager.publish_message(json_str)
+            event_id = json_data[1].get("id", "") if len(json_data) > 1 else ""
+            if not nostr_client.relay_manager.relays:
+                # NIP-01: OK with failure when no relays are connected
+                await self.websocket.send_text(
+                    json.dumps(["OK", event_id, False, "error: no relay connections"])
+                )
+            else:
+                nostr_client.relay_manager.publish_message(json_str)
+                # NIP-01: OK response so clients know the event was accepted
+                await self.websocket.send_text(
+                    json.dumps(["OK", event_id, True, ""])
+                )
             return
 
-    def _handle_client_req(self, json_data):
+    async def _handle_client_req(self, json_data):
         subscription_id = json_data[1]
         logger.info(f"New subscription: '{subscription_id}'")
+        if not nostr_client.relay_manager.relays:
+            # NIP-01: CLOSED when relay refuses to fulfill a REQ
+            await self.websocket.send_text(
+                json.dumps(["CLOSED", subscription_id, "error: no relay connections"])
+            )
+            return
         subscription_id_rewritten = urlsafe_short_hash()
         self.original_subscription_ids[subscription_id_rewritten] = subscription_id
         filters = json_data[2:]

--- a/router.py
+++ b/router.py
@@ -150,9 +150,7 @@ class NostrRouter:
             else:
                 nostr_client.relay_manager.publish_message(json_str)
                 # NIP-01: OK response so clients know the event was accepted
-                await self.websocket.send_text(
-                    json.dumps(["OK", event_id, True, ""])
-                )
+                await self.websocket.send_text(json.dumps(["OK", event_id, True, ""]))
             return
 
     async def _handle_client_req(self, json_data):


### PR DESCRIPTION
## Summary

The relay proxy was not sending NIP-01 required responses after receiving `EVENT` and `REQ` messages from clients.

### Changes

- **EVENT → OK response**: When a client publishes an EVENT, the relay now responds with:
  - `["OK", event_id, true, ""]` when the event is forwarded to upstream relays
  - `["OK", event_id, false, "error: no relay connections"]` when no relays are connected
- **REQ → CLOSED response**: When a client sends a REQ but no relays are connected, the relay responds with:
  - `["CLOSED", subscription_id, "error: no relay connections"]`

### Why this matters

NIP-01 states:
> OK messages MUST be sent in response to EVENT messages received from clients

Without OK responses, NWC clients using `nostr-tools` `SimplePool.publish()` timeout after 4.4s waiting for confirmation, causing `Nip47PublishError: failed to publish: AggregateError: All promises were rejected`. This makes NWC connections unreliable — payments may succeed on the backend but the client reports failure, risking double payments from user retries.

### Testing

Verified by connecting directly via WebSocket:

**Before patch:**
```
> ["EVENT", {signed_event}]
(no response - timeout after 4.4s)
```

**After patch:**
```
> ["EVENT", {signed_event}]
< ["OK", "e830dca0...", true, ""]
```

Tested with the `@getalby/sdk` NWC client — NWC `get_balance`, `pay_invoice`, and `list_transactions` all work reliably after this fix.

Fixes #52
Related: #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)