### PR TITLE
fix: add thread-safety lock to shared ClassVar state

### DIFF
--- a/router.py
+++ b/router.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import threading
 from typing import ClassVar
 
 from fastapi import WebSocket, WebSocketDisconnect
@@ -21,6 +22,7 @@ class NostrRouter:
     received_subscription_eosenotices: ClassVar[dict[str, EndOfStoredEventsMessage]] = (
         {}
     )
+    lock: ClassVar[threading.Lock] = threading.Lock()
 
     def __init__(self, websocket: WebSocket):
         self.connected: bool = True
@@ -92,9 +94,10 @@ class NostrRouter:
             if s not in self.original_subscription_ids:
                 return
             s_original = self.original_subscription_ids[s]
-            event_to_forward = ["EOSE", s_original]
-            del NostrRouter.received_subscription_eosenotices[s]
+            with NostrRouter.lock:
+                del NostrRouter.received_subscription_eosenotices[s]
 
+            event_to_forward = ["EOSE", s_original]
             await self.websocket.send_text(json.dumps(event_to_forward))
         except Exception as e:
             logger.debug(e)
@@ -104,8 +107,11 @@ class NostrRouter:
             if s not in NostrRouter.received_subscription_events:
                 return
 
-            while len(NostrRouter.received_subscription_events[s]):
-                event_message = NostrRouter.received_subscription_events[s].pop(0)
+            while True:
+                with NostrRouter.lock:
+                    if not NostrRouter.received_subscription_events[s]:
+                        break
+                    event_message = NostrRouter.received_subscription_events[s].pop(0)
                 event_json = event_message.event
 
                 # this reconstructs the original response from the relay
@@ -121,8 +127,11 @@ class NostrRouter:
             )
 
     def _handle_notices(self):
-        while len(NostrRouter.received_subscription_notices):
-            my_event = NostrRouter.received_subscription_notices.pop(0)
+        while True:
+            with NostrRouter.lock:
+                if not NostrRouter.received_subscription_notices:
+                    break
+                my_event = NostrRouter.received_subscription_notices.pop(0)
             logger.debug(f"[Relay '{my_event.url}'] Notice: '{my_event.content}']")
             #  Note: we don't send it to the user because
             #  we don't know who should receive it
@@ -165,11 +174,9 @@ class NostrRouter:
         if subscription_id_rewritten:
             self.original_subscription_ids.pop(subscription_id_rewritten)
             nostr_client.relay_manager.close_subscription(subscription_id_rewritten)
-            logger.info(
-                f"""
+            logger.info(f"""
             Unsubscribe from '{subscription_id_rewritten}'.
             Original id: '{subscription_id}.'
-            """
-            )
+            """)
         else:
             logger.info(f"Failed to unsubscribe from '{subscription_id}.'")

--- a/tasks.py
+++ b/tasks.py
@@ -32,28 +32,31 @@ async def subscribe_events():
         await asyncio.sleep(2)
 
     def callback_events(event_message: EventMessage):
-        sub_id = event_message.subscription_id
-        if sub_id not in NostrRouter.received_subscription_events:
-            NostrRouter.received_subscription_events[sub_id] = [event_message]
-            return
+        with NostrRouter.lock:
+            sub_id = event_message.subscription_id
+            if sub_id not in NostrRouter.received_subscription_events:
+                NostrRouter.received_subscription_events[sub_id] = [event_message]
+                return
 
-        # do not add duplicate events (by event id)
-        ids = [e.event_id for e in NostrRouter.received_subscription_events[sub_id]]
-        if event_message.event_id in ids:
-            return
+            # do not add duplicate events (by event id)
+            ids = [e.event_id for e in NostrRouter.received_subscription_events[sub_id]]
+            if event_message.event_id in ids:
+                return
 
-        NostrRouter.received_subscription_events[sub_id].append(event_message)
+            NostrRouter.received_subscription_events[sub_id].append(event_message)
 
     def callback_notices(notice_message: NoticeMessage):
-        if notice_message not in NostrRouter.received_subscription_notices:
-            NostrRouter.received_subscription_notices.append(notice_message)
+        with NostrRouter.lock:
+            if notice_message not in NostrRouter.received_subscription_notices:
+                NostrRouter.received_subscription_notices.append(notice_message)
 
     def callback_eose_notices(event_message: EndOfStoredEventsMessage):
-        sub_id = event_message.subscription_id
-        if sub_id in NostrRouter.received_subscription_eosenotices:
-            return
+        with NostrRouter.lock:
+            sub_id = event_message.subscription_id
+            if sub_id in NostrRouter.received_subscription_eosenotices:
+                return
 
-        NostrRouter.received_subscription_eosenotices[sub_id] = event_message
+            NostrRouter.received_subscription_eosenotices[sub_id] = event_message
 
     def wrap_async_subscribe():
         asyncio.run(


### PR DESCRIPTION
## Problem

`NostrRouter` uses three `ClassVar` collections to shuttle events from relays to WebSocket clients:

- `received_subscription_events`
- `received_subscription_eosenotices`
- `received_subscription_notices`

These are **written by a daemon thread** (the `subscribe_events` background task via callbacks in `tasks.py`) and **read/deleted by asyncio tasks** (the `_nostr_to_client` loop in `router.py`). No synchronization protects these shared data structures.

This race condition causes non-deterministic loss of events and EOSE messages. Downstream consumers like the NWC Service Provider wait indefinitely for EOSE that never arrives, causing "all promises rejected" errors in client wallets.

## Fix

- Added `threading.Lock` as a `ClassVar` on `NostrRouter`
- Wrapped all reads/writes to the three shared collections with `with NostrRouter.lock:`
- Only the actual data mutation is locked (not the `await send_text` calls), minimizing lock contention

The lock is held only for the duration of the list/dict mutation (pop, del, read), not across the `await` that sends the event to the WebSocket client. This keeps critical sections minimal while ensuring thread safety.

## Testing

- Verified the provider processes requests reliably without EOSE loss
- No behavioral change when there is no contention (single client)
- Python syntax verified