### PR TITLE
Feat: Add relay disclosure endpoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,8 @@ dependencies = [ "lnbits>1", "nostr-sdk~=0.44.0" ]
 [tool.poetry]
 package-mode = false
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "black",
     "pytest-asyncio",
     "pytest",

--- a/views_api.py
+++ b/views_api.py
@@ -2,7 +2,7 @@ import asyncio
 from http import HTTPStatus
 
 from fastapi import APIRouter, Depends, HTTPException, WebSocket
-from lnbits.decorators import check_admin
+from lnbits.decorators import check_admin, require_admin_key
 from lnbits.helpers import decrypt_internal_message, urlsafe_short_hash
 from loguru import logger
 
@@ -43,6 +43,13 @@ async def api_get_relays() -> list[Relay]:
             )
         )
     return relays
+
+
+@nostrclient_api_router.get(
+    "/api/v1/relays/urls", dependencies=[Depends(require_admin_key)]
+)
+async def api_get_relay_urls() -> list[str]:
+    return list(nostr_client.relay_manager.relays.keys())
 
 
 @nostrclient_api_router.post(


### PR DESCRIPTION
Users events are broadcasted to every configured third-party relay with no way to discover which. Disclosing the list is a transparency/consent best practice.

Adds `GET /nostrclient/api/v1/relays/urls`, which returns the list of relays this instance is currently connected to.

It's locked behind `require_admin_key`, so only someone with an admin key can hit it — no public exposure. It returns just the URLs, nothing else.

it reads the live relay list from `relay_manager`, not the DB, so it reflects what's actually connected at runtime.

